### PR TITLE
Python 2 base image modification to prevent docker build from failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 # Install xmlsec1
 RUN echo 'deb http://mirror.isoc.org.il/pub/ubuntu/ trusty main universe' >> /etc/apt/sources.list && \


### PR DESCRIPTION
With the base image set at `python:2.7`, docker build failed when installing python dependencies